### PR TITLE
Xcode 6.3 support

### DIFF
--- a/Moscapsule.xcodeproj/project.pbxproj
+++ b/Moscapsule.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -464,7 +464,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -489,6 +489,7 @@
 				);
 				INFOPLIST_FILE = Moscapsule/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "./submodules/OpenSSL/lib-ios";
 				OTHER_CFLAGS = (
@@ -522,6 +523,7 @@
 				);
 				INFOPLIST_FILE = Moscapsule/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "./submodules/OpenSSL/lib-ios";
 				OTHER_CFLAGS = (

--- a/Moscapsule/Moscapsule.swift
+++ b/Moscapsule/Moscapsule.swift
@@ -247,7 +247,7 @@ public class MQTTConfig {
 
 @objc(__MosquittoContext)
 public final class __MosquittoContext {
-    public var mosquittoHandler: COpaquePointer = COpaquePointer.null()
+    public var mosquittoHandler: COpaquePointer = nil
     public var isConnected: Bool = false
     public var onConnectCallback: ((returnCode: Int) -> ())!
     public var onDisconnectCallback: ((reasonCode: Int) -> ())!
@@ -267,7 +267,7 @@ public final class MQTTMessage {
     public let retain: Bool
 
     public var payloadString: String? {
-        return NSString(data: payload, encoding: NSUTF8StringEncoding)
+        return NSString(data: payload, encoding: NSUTF8StringEncoding) as? String
     }
 
     internal init(messageId: Int, topic: String, payload: NSData, qos: Int32, retain: Bool) {
@@ -416,7 +416,7 @@ public final class MQTTClient {
 
     public func publishString(payload: String, topic: String, qos: Int32, retain: Bool, requestCompletion: ((MosqResult, Int) -> ())? = nil) {
         if let payloadData = (payload as NSString).dataUsingEncoding(NSUTF8StringEncoding) {
-            publish(payloadData, topic: topic, qos: qos, retain: retain, requestCompletion)
+            publish(payloadData, topic: topic, qos: qos, retain: retain, requestCompletion: requestCompletion)
         }
     }
 


### PR DESCRIPTION
Fixed some syntax errors to compile with Swift 1.2 / Xcode 6.3.
These changes may be incompatible with previous versions of Xcode.