### PR TITLE
Update use of fromCString to handle bad UTF-8

### DIFF
--- a/Moscapsule/Moscapsule.swift
+++ b/Moscapsule/Moscapsule.swift
@@ -204,10 +204,8 @@ public struct MQTTMessage {
     public let qos: Int32
     public let retain: Bool
 
-    // If the String version has issues, return the substitutions
     public var payloadString: String? {
-        let (myString,_) = String.fromCStringRepairingIllFormedUTF8(String(payload))
-        return myString
+        return NSString(data: payload, encoding: NSUTF8StringEncoding) as? String
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Moscapsule
 
 MQTT Client for iOS written in Swift.  
 This framework is implemented as a wrapper of Mosquitto library and covers almost all mosquitto features.  
-It uses Mosquitto version 1.4.2.
+It uses Mosquitto version 1.4.8.
 
 Mosquitto
 ---------

--- a/mosquitto/lib/memory_mosq.c
+++ b/mosquitto/lib/memory_mosq.c
@@ -54,6 +54,9 @@ void *_mosquitto_calloc(size_t nmemb, size_t size)
 void _mosquitto_free(void *mem)
 {
 #ifdef REAL_WITH_MEMORY_TRACKING
+	if(!mem){
+		return;
+	}
 	memcount -= malloc_usable_size(mem);
 #endif
 	free(mem);

--- a/mosquitto/lib/memory_mosq.h
+++ b/mosquitto/lib/memory_mosq.h
@@ -20,7 +20,7 @@ Contributors:
 #include <stdio.h>
 #include <sys/types.h>
 
-#if defined(WITH_MEMORY_TRACKING) && defined(WITH_BROKER) && !defined(WIN32) && !defined(__SYMBIAN32__) && !defined(__ANDROID__) && !defined(__UCLIBC__)
+#if defined(WITH_MEMORY_TRACKING) && defined(WITH_BROKER) && !defined(WIN32) && !defined(__SYMBIAN32__) && !defined(__ANDROID__) && !defined(__UCLIBC__) && !defined(__OpenBSD__)
 #define REAL_WITH_MEMORY_TRACKING
 #endif
 

--- a/mosquitto/lib/messages_mosq.c
+++ b/mosquitto/lib/messages_mosq.c
@@ -106,8 +106,18 @@ void mosquitto_message_free(struct mosquitto_message **message)
 	_mosquitto_free(msg);
 }
 
-void _mosquitto_message_queue(struct mosquitto *mosq, struct mosquitto_message_all *message, enum mosquitto_msg_direction dir)
+
+/*
+ * Function: _mosquitto_message_queue
+ *
+ * Returns:
+ *	0 - to indicate an outgoing message can be started
+ *	1 - to indicate that the outgoing message queue is full (inflight limit has been reached)
+ */
+int _mosquitto_message_queue(struct mosquitto *mosq, struct mosquitto_message_all *message, enum mosquitto_msg_direction dir)
 {
+	int rc = 0;
+
 	/* mosq->*_message_mutex should be locked before entering this function */
 	assert(mosq);
 	assert(message);
@@ -121,8 +131,12 @@ void _mosquitto_message_queue(struct mosquitto *mosq, struct mosquitto_message_a
 			mosq->out_messages = message;
 		}
 		mosq->out_messages_last = message;
-		if(message->msg.qos > 0 && (mosq->max_inflight_messages == 0 || mosq->inflight_messages < mosq->max_inflight_messages)){
-			mosq->inflight_messages++;
+		if(message->msg.qos > 0){
+			if(mosq->max_inflight_messages == 0 || mosq->inflight_messages < mosq->max_inflight_messages){
+				mosq->inflight_messages++;
+			}else{
+				rc = 1;
+			}
 		}
 	}else{
 		mosq->in_queue_len++;
@@ -134,6 +148,7 @@ void _mosquitto_message_queue(struct mosquitto *mosq, struct mosquitto_message_a
 		}
 		mosq->in_messages_last = message;
 	}
+	return rc;
 }
 
 void _mosquitto_messages_reconnect_reset(struct mosquitto *mosq)
@@ -177,10 +192,10 @@ void _mosquitto_messages_reconnect_reset(struct mosquitto *mosq)
 		mosq->out_queue_len++;
 		message->timestamp = 0;
 
-		if(message->msg.qos > 0){
-			mosq->inflight_messages++;
-		}
 		if(mosq->max_inflight_messages == 0 || mosq->inflight_messages < mosq->max_inflight_messages){
+			if(message->msg.qos > 0){
+				mosq->inflight_messages++;
+			}
 			if(message->msg.qos == 1){
 				message->state = mosq_ms_wait_for_puback;
 			}else if(message->msg.qos == 2){

--- a/mosquitto/lib/messages_mosq.h
+++ b/mosquitto/lib/messages_mosq.h
@@ -22,7 +22,7 @@ Contributors:
 void _mosquitto_message_cleanup_all(struct mosquitto *mosq);
 void _mosquitto_message_cleanup(struct mosquitto_message_all **message);
 int _mosquitto_message_delete(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg_direction dir);
-void _mosquitto_message_queue(struct mosquitto *mosq, struct mosquitto_message_all *message, enum mosquitto_msg_direction dir);
+int _mosquitto_message_queue(struct mosquitto *mosq, struct mosquitto_message_all *message, enum mosquitto_msg_direction dir);
 void _mosquitto_messages_reconnect_reset(struct mosquitto *mosq);
 int _mosquitto_message_remove(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg_direction dir, struct mosquitto_message_all **message);
 void _mosquitto_message_retry_check(struct mosquitto *mosq);

--- a/mosquitto/lib/mosquitto.h
+++ b/mosquitto/lib/mosquitto.h
@@ -45,7 +45,7 @@ extern "C" {
 
 #define LIBMOSQUITTO_MAJOR 1
 #define LIBMOSQUITTO_MINOR 4
-#define LIBMOSQUITTO_REVISION 2
+#define LIBMOSQUITTO_REVISION 8
 /* LIBMOSQUITTO_VERSION_NUMBER looks like 1002001 for e.g. version 1.2.1. */
 #define LIBMOSQUITTO_VERSION_NUMBER (LIBMOSQUITTO_MAJOR*1000000+LIBMOSQUITTO_MINOR*1000+LIBMOSQUITTO_REVISION)
 
@@ -576,6 +576,7 @@ libmosq_EXPORT int mosquitto_disconnect(struct mosquitto *mosq);
  *               Note that although the MQTT protocol doesn't use message ids
  *               for messages with QoS=0, libmosquitto assigns them message ids
  *               so they can be tracked with this parameter.
+ *  topic -      null terminated string of the topic to publish to.
  * 	payloadlen - the size of the payload (bytes). Valid values are between 0 and
  *               268,435,455.
  * 	payload -    pointer to the data to send. If payloadlen > 0 this must be a

--- a/mosquitto/lib/mosquitto_internal.h
+++ b/mosquitto/lib/mosquitto_internal.h
@@ -207,8 +207,12 @@ struct mosquitto {
 	int sub_count;
 	int pollfd_index;
 #  ifdef WITH_WEBSOCKETS
+#    if defined(LWS_LIBRARY_VERSION_NUMBER)
+	struct lws *wsi;
+#    else
 	struct libwebsocket_context *ws_context;
 	struct libwebsocket *wsi;
+#    endif
 #  endif
 #else
 #  ifdef WITH_SOCKS
@@ -256,5 +260,7 @@ struct mosquitto {
 	struct mosquitto *for_free_next;
 #endif
 };
+
+#define STREMPTY(str) (str[0] == '\0')
 
 #endif

--- a/mosquitto/lib/net_mosq.c
+++ b/mosquitto/lib/net_mosq.c
@@ -81,6 +81,8 @@ Contributors:
 #include <time_mosq.h>
 #include <util_mosq.h>
 
+#include "config.h"
+
 #ifdef WITH_TLS
 int tls_ex_index_mosq = -1;
 #endif
@@ -710,6 +712,7 @@ ssize_t _mosquitto_net_write(struct mosquitto *mosq, void *buf, size_t count)
 	errno = 0;
 #ifdef WITH_TLS
 	if(mosq->ssl){
+		mosq->want_write = false;
 		ret = SSL_write(mosq->ssl, buf, count);
 		if(ret < 0){
 			err = SSL_get_error(mosq->ssl, ret);
@@ -1123,10 +1126,6 @@ int _mosquitto_socketpair(mosq_sock_t *pairR, mosq_sock_t *pairW)
 			continue;
 		}
 
-		if(_mosquitto_socket_nonblock(listensock)){
-			continue;
-		}
-
 		if(family[i] == AF_INET){
 			sa->sin_family = family[i];
 			sa->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
@@ -1143,6 +1142,7 @@ int _mosquitto_socketpair(mosq_sock_t *pairR, mosq_sock_t *pairW)
 			continue;
 		}
 		if(_mosquitto_socket_nonblock(spR)){
+			COMPAT_CLOSE(spR);
 			COMPAT_CLOSE(listensock);
 			continue;
 		}
@@ -1170,6 +1170,7 @@ int _mosquitto_socketpair(mosq_sock_t *pairR, mosq_sock_t *pairW)
 
 		if(_mosquitto_socket_nonblock(spW)){
 			COMPAT_CLOSE(spR);
+			COMPAT_CLOSE(spW);
 			COMPAT_CLOSE(listensock);
 			continue;
 		}

--- a/mosquitto/lib/send_client_mosq.c
+++ b/mosquitto/lib/send_client_mosq.c
@@ -99,9 +99,6 @@ int _mosquitto_send_connect(struct mosquitto *mosq, uint16_t keepalive, bool cle
 		_mosquitto_write_string(packet, PROTOCOL_NAME_v31, strlen(PROTOCOL_NAME_v31));
 	}else if(version == MQTT_PROTOCOL_V311){
 		_mosquitto_write_string(packet, PROTOCOL_NAME_v311, strlen(PROTOCOL_NAME_v311));
-	}else{
-		_mosquitto_free(packet);
-		return MOSQ_ERR_INVAL;
 	}
 #if defined(WITH_BROKER) && defined(WITH_BRIDGE)
 	if(mosq->bridge && mosq->bridge->try_private && mosq->bridge->try_private_accepted){

--- a/mosquitto/lib/socks_mosq.c
+++ b/mosquitto/lib/socks_mosq.c
@@ -352,13 +352,6 @@ int mosquitto__socks5_read(struct mosquitto *mosq)
 				_mosquitto_packet_cleanup(&mosq->in_packet);
 				return MOSQ_ERR_NOMEM;
 			}
-			payload = _mosquitto_realloc(mosq->in_packet.payload, mosq->in_packet.packet_length);
-			if(payload){
-				mosq->in_packet.payload = payload;
-			}else{
-				_mosquitto_packet_cleanup(&mosq->in_packet);
-				return MOSQ_ERR_NOMEM;
-			}
 			return MOSQ_ERR_SUCCESS;
 		}
 

--- a/mosquitto/lib/thread_mosq.c
+++ b/mosquitto/lib/thread_mosq.c
@@ -89,7 +89,7 @@ void *_mosquitto_thread_main(void *obj)
 
 	if(!mosq->keepalive){
 		/* Sleep for a day if keepalive disabled. */
-		mosquitto_loop_forever(mosq, mosq->keepalive*1000*86400, 1);
+		mosquitto_loop_forever(mosq, 1000*86400, 1);
 	}else{
 		/* Sleep for our keepalive value. publish() etc. will wake us up. */
 		mosquitto_loop_forever(mosq, mosq->keepalive*1000, 1);

--- a/mosquitto/lib/tls_mosq.c
+++ b/mosquitto/lib/tls_mosq.c
@@ -21,6 +21,7 @@ Contributors:
 #  include <ws2tcpip.h>
 #else
 #  include <arpa/inet.h>
+#  include <sys/socket.h>
 #endif
 
 #include <string.h>

--- a/mosquitto/lib/tls_mosq.h
+++ b/mosquitto/lib/tls_mosq.h
@@ -18,6 +18,12 @@ Contributors:
 #define _TLS_MOSQ_H_
 
 #ifdef WITH_TLS
+#  define SSL_DATA_PENDING(A) ((A)->ssl && SSL_pending((A)->ssl))
+#else
+#  define SSL_DATA_PENDING(A) 0
+#endif
+
+#ifdef WITH_TLS
 
 #include <openssl/ssl.h>
 #ifdef WITH_TLS_PSK


### PR DESCRIPTION
Update onMessageAdapter
- Fall out and drop message on the floor if UTF-8 issues are seeing
when processing topic field

Testing note: Subscribing to # on test.mosquitto.org works without a
crash after these changes.