### PR TITLE
Update onMessageAdapter to drop out if fromCString fails

### DIFF
--- a/Moscapsule/Moscapsule.swift
+++ b/Moscapsule/Moscapsule.swift
@@ -334,10 +334,12 @@ public final class MQTT {
     private class func onMessageAdapter(callback: ((MQTTMessage) -> ())!) -> ((UnsafePointer<mosquitto_message>) -> ())! {
         return callback == nil ? nil : { (rawMessage: UnsafePointer<mosquitto_message>) in
             let message = rawMessage.memory
-            let topic = String.fromCString(message.topic)!
-            let payload = NSData(bytes: message.payload, length: Int(message.payloadlen))
-            let mqttMessage = MQTTMessage(messageId: Int(message.mid), topic: topic, payload: payload, qos: message.qos, retain: message.retain)
-            callback(mqttMessage)
+            // If there are issues with topic string, drop message on the floor
+            if let topic = String.fromCString(message.topic) {
+                let payload = NSData(bytes: message.payload, length: Int(message.payloadlen))
+                let mqttMessage = MQTTMessage(messageId: Int(message.mid), topic: topic, payload: payload, qos: message.qos, retain: message.retain)
+                callback(mqttMessage)
+            }
         }
     }
 


### PR DESCRIPTION
This change prevents crashes in the message callback if topic cannot be converted to UTF-8. On a failure in fromCString topic can be set to nil.