### PR TITLE
payloadString will try do convert payload NSData using all String encodings before returning nil

### DIFF
--- a/Moscapsule/Moscapsule.swift
+++ b/Moscapsule/Moscapsule.swift
@@ -252,13 +252,14 @@ public struct MQTTMessage {
     public let retain: Bool
 
     public var payloadString: String? {
-        if let utf8String = String(data: payload, encoding: NSUTF8StringEncoding) {
-            return utf8String
-        } else if let asciiString = String(data: payload, encoding: NSASCIIStringEncoding) {
-            return asciiString
-        } else {
-            return nil
+        let encodingsToTry = [NSUTF8StringEncoding, NSASCIIStringEncoding]
+        for encoding in encodingsToTry {
+            if let string = String(data: payload, encoding: encoding) {
+                return string
+            }
         }
+        
+        return nil
     }
 }
 

--- a/Moscapsule/Moscapsule.swift
+++ b/Moscapsule/Moscapsule.swift
@@ -252,7 +252,16 @@ public struct MQTTMessage {
     public let retain: Bool
 
     public var payloadString: String? {
-        let encodingsToTry = [NSUTF8StringEncoding, NSASCIIStringEncoding]
+        let encodingsToTry = [
+            NSUTF8StringEncoding, NSASCIIStringEncoding, NSUTF16StringEncoding, NSUTF16BigEndianStringEncoding,
+            NSUTF16LittleEndianStringEncoding, NSUTF32StringEncoding, NSUTF32BigEndianStringEncoding,
+            NSUTF32LittleEndianStringEncoding, NSNEXTSTEPStringEncoding, NSJapaneseEUCStringEncoding,
+            NSISOLatin1StringEncoding, NSSymbolStringEncoding, NSNonLossyASCIIStringEncoding, NSShiftJISStringEncoding,
+            NSISOLatin2StringEncoding, NSUnicodeStringEncoding, NSWindowsCP1251StringEncoding, NSWindowsCP1252StringEncoding,
+            NSWindowsCP1253StringEncoding, NSWindowsCP1254StringEncoding, NSWindowsCP1250StringEncoding,
+            NSISO2022JPStringEncoding, NSMacOSRomanStringEncoding
+        ]
+        
         for encoding in encodingsToTry {
             if let string = String(data: payload, encoding: encoding) {
                 return string

--- a/Moscapsule/Moscapsule.swift
+++ b/Moscapsule/Moscapsule.swift
@@ -252,7 +252,13 @@ public struct MQTTMessage {
     public let retain: Bool
 
     public var payloadString: String? {
-        return NSString(data: payload, encoding: NSUTF8StringEncoding) as? String
+        if let utf8String = String(data: payload, encoding: NSUTF8StringEncoding) {
+            return utf8String
+        } else if let asciiString = String(data: payload, encoding: NSASCIIStringEncoding) {
+            return asciiString
+        } else {
+            return nil
+        }
     }
 }
 


### PR DESCRIPTION
Changed to try all encodings when converting the payload `NSData` to `String` when accessing the public var `payloadString`.

The `NSUTF8StringEncoding` stays first in the array to keep the previous behavior and have no impact in existing codes, except in cases that the conversion would fail. 

The `NSASCIIStringEncoding` stays second because it solved a problem I had with the character `0xFF`. 

The sequence `NSUTF16StringEncoding, NSUTF16BigEndianStringEncoding, NSUTF16LittleEndianStringEncoding, NSUTF32StringEncoding, NSUTF32BigEndianStringEncoding, NSUTF32LittleEndianStringEncoding` was added next because I think this is more common than the others encodings, therefore the conversion will succeed earlier in most cases.