### PR TITLE
Fix issue with zombie threads

### DIFF
--- a/mosquitto/lib/mosquitto.h
+++ b/mosquitto/lib/mosquitto.h
@@ -1246,6 +1246,8 @@ libmosq_EXPORT void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on
  * between reconnections by setting reconnect_exponential_backoff to true and
  * set an upper bound on the delay with reconnect_delay_max.
  *
+ * This function will enable reconnecting if it was disabled before.
+ *
  * Example 1:
  *	delay=2, delay_max=10, exponential_backoff=False
  *	Delays would be: 2, 4, 6, 8, 10, 10, ...
@@ -1269,6 +1271,26 @@ libmosq_EXPORT void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on
  * 	MOSQ_ERR_INVAL -   if the input parameters were invalid.
  */
 libmosq_EXPORT int mosquitto_reconnect_delay_set(struct mosquitto *mosq, unsigned int reconnect_delay, unsigned int reconnect_delay_max, bool reconnect_exponential_backoff);
+	
+/*
+ * Function: mosquitto_reconnect_disable
+ *
+ * Control the behaviour of the client when it has unexpectedly disconnected in
+ * <mosquitto_loop_forever> or after <mosquitto_loop_start>. The default
+ * behaviour if this function is not used is to repeatedly attempt to reconnect
+ * with a delay of 1 second until the connection succeeds.
+ *
+ * Use this function for disabling auto reconnecting.
+ *
+ *
+ * Parameters:
+ *  mosq -                          a valid mosquitto instance.
+ *
+ * Returns:
+ *	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ */
+libmosq_EXPORT int mosquitto_reconnect_disable(struct mosquitto *mosq);
 
 /*
  * Function: mosquitto_max_inflight_messages_set

--- a/mosquitto/lib/mosquitto_internal.h
+++ b/mosquitto/lib/mosquitto_internal.h
@@ -245,6 +245,7 @@ struct mosquitto {
 	unsigned int reconnect_delay;
 	unsigned int reconnect_delay_max;
 	bool reconnect_exponential_backoff;
+	bool reconnect_enabled;
 	bool threaded;
 	struct _mosquitto_packet *out_packet_last;
 	int inflight_messages;


### PR DESCRIPTION
#51 
Issue: if I call `disabledReconn`, it will set maximum integer value to delay. So, if connection was broken, then it will call sleep with almost infinite value and thread will not be removed even if I call `disconnect`.