### PR TITLE
Bugfix/pw callback crash

### DIFF
--- a/Moscapsule.podspec
+++ b/Moscapsule.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "Moscapsule"
-  s.version      = "0.5.3"
+  s.version      = "0.5.4"
   s.summary      = "MQTT Client for iOS written in Swift"
   s.description  = <<-DESC
                    MQTT Client for iOS written in Swift.

--- a/mosquitto/lib/net_mosq.c
+++ b/mosquitto/lib/net_mosq.c
@@ -486,7 +486,7 @@ int _mosquitto_socket_connect(struct mosquitto *mosq, const char *host, uint16_t
 
 			if(mosq->tls_pw_callback){
 				SSL_CTX_set_default_passwd_cb(mosq->ssl_ctx, mosq->tls_pw_callback);
-				SSL_CTX_set_default_passwd_cb_userdata(mosq->ssl_ctx, mosq);
+				SSL_CTX_set_default_passwd_cb_userdata(mosq->ssl_ctx, mosq->userdata);
 			}
 
 			if(mosq->tls_certfile){


### PR DESCRIPTION
Wanted to use password for private key. But the app was crashing when I tried, a pointer was referencing to a deallocated object. After long and painful investigation, it's working now :) There was a bug in the Moscapsule library, a wrong object was passed to OpenSSL. So I forked the orig lib and fixed it. Plz verify.

Should I also create a pull request back to the main lib repo? (after the review)