### PR TITLE
Fixed crash when using password-protected private key file

### DIFF
--- a/Moscapsule.podspec
+++ b/Moscapsule.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "Moscapsule"
-  s.version      = "0.5.3"
+  s.version      = "0.5.4"
   s.summary      = "MQTT Client for iOS written in Swift"
   s.description  = <<-DESC
                    MQTT Client for iOS written in Swift.

--- a/mosquitto/lib/net_mosq.c
+++ b/mosquitto/lib/net_mosq.c
@@ -486,7 +486,7 @@ int _mosquitto_socket_connect(struct mosquitto *mosq, const char *host, uint16_t
 
 			if(mosq->tls_pw_callback){
 				SSL_CTX_set_default_passwd_cb(mosq->ssl_ctx, mosq->tls_pw_callback);
-				SSL_CTX_set_default_passwd_cb_userdata(mosq->ssl_ctx, mosq);
+				SSL_CTX_set_default_passwd_cb_userdata(mosq->ssl_ctx, mosq->userdata);
 			}
 
 			if(mosq->tls_certfile){

--- a/mosquitto/lib/net_mosq.c
+++ b/mosquitto/lib/net_mosq.c
@@ -486,7 +486,9 @@ int _mosquitto_socket_connect(struct mosquitto *mosq, const char *host, uint16_t
 
 			if(mosq->tls_pw_callback){
 				SSL_CTX_set_default_passwd_cb(mosq->ssl_ctx, mosq->tls_pw_callback);
-				SSL_CTX_set_default_passwd_cb_userdata(mosq->ssl_ctx, mosq->userdata);
+				if(mosq->userdata) {
+				  SSL_CTX_set_default_passwd_cb_userdata(mosq->ssl_ctx, mosq->userdata);
+				}
 			}
 
 			if(mosq->tls_certfile){


### PR DESCRIPTION
Noticed a crash (EXC_BAD_ACCESS) on the password callback (`pw_callback` in `MosquittoCallbackBridge`) when it tries to cast the userdata object. I passed in the password of the private key file via `MQTTClientCert` object on `MQTTConfig`.

Found the problem was that `mosq` was passed in as the userdata instead of `mosq->userdata`. See the diff.

Hope this makes sense! :) 

Btw for completeness, here's how I encrypted the private key:
`$ openssl pkcs8 -topk8 -v2 des3 -in mqtt.key -out mqtt-encrypted.key`
