### PR TITLE
Enable application extension API only.

### DIFF
--- a/Moscapsule.xcodeproj/project.pbxproj
+++ b/Moscapsule.xcodeproj/project.pbxproj
@@ -497,6 +497,7 @@
 		09CF6B2A1A21F78700A97383 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -535,6 +536,7 @@
 		09CF6B2B1A21F78700A97383 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Allows Moscapsule to be used in app extensions too!